### PR TITLE
Adding Application.Read.All

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,12 @@ resource "azuread_application" "terrakube_api" {
       id   =  "98830695-27a2-44f7-8c18-0c3ebc9698f6" #  Microsoft Graph GroupMember.Read.All
       type = "Role"
     }
+
+    resource_access {
+      id   =  "	9a5d68dd-52b0-4cc2-bd40-abcf44ac3a30" #  Microsoft Graph Application.Read.All
+      type = "Role"
+    }
+
   }
 
   single_page_application {

--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ resource "azuread_application" "terrakube_api" {
     }
 
     resource_access {
-      id   =  "	9a5d68dd-52b0-4cc2-bd40-abcf44ac3a30" #  Microsoft Graph Application.Read.All
+      id   =  "9a5d68dd-52b0-4cc2-bd40-abcf44ac3a30" #  Microsoft Graph Application.Read.All
       type = "Role"
     }
 


### PR DESCRIPTION
Terakube App needs Application.Read.All inside Azure Active Directory to check application membership inside Azure Ad Groups.

```bash
POST /servicePrincipals/{id}/checkMemberGroups
```

Reference: 
- https://docs.microsoft.com/en-us/graph/api/directoryobject-checkmembergroups?view=graph-rest-1.0&tabs=http
- https://docs.microsoft.com/en-us/graph/permissions-reference